### PR TITLE
[NumberZapExt] zapToNumber stops pseudo recordings for SpecialJump co…

### DIFF
--- a/usr/lib/enigma2/python/Plugins/SystemPlugins/NumberZapExt/plugin.py
+++ b/usr/lib/enigma2/python/Plugins/SystemPlugins/NumberZapExt/plugin.py
@@ -118,6 +118,14 @@ def actionConfirmed(self, action, retval):
 					self.session.open(*eval(openstr))
 
 def zapToNumber(self, number, bouquet, startBouquet, checkParentalControl=True, ref=None):
+	import NavigationInstance
+	from enigma import pNavigation
+	try:
+		#not all images support recording type indicators
+		for rec in NavigationInstance.instance.getRecordings(False,pNavigation.isFromSpecialJumpFastZap):
+			NavigationInstance.instance.stopRecordService(rec)
+	except:
+		pass
 	if checkParentalControl:
 		service, bouquet = getServiceFromNumber(self, number, config.plugins.NumberZapExt.acount.value, bouquet, startBouquet)
 	else:


### PR DESCRIPTION
…mpatibility

At openATV the plugin 'SpecialJump' includes a feature for faster zapping by pre-loading the next service on a free tuner.
For avoiding that the tuner remains permanently blocked when using NumberZapExt's 'zapToNumber', I'm proposing this patch.
It has been tested successfully for more than one year at openATV.
The 'try/except' should make sure there are no side effects on other images.
See also:
http://www.opena.tv/plugins/6240-specialjump-plugin-zum-schnellen-manuellen-ueberspringen-von-werbung-und-mehr.html
http://www.opena.tv/plugins/6240-specialjump-plugin-zum-schnellen-manuellen-ueberspringen-von-werbung-und-mehr-15.html#post245997
http://www.opena.tv/allgemeine-image-informationen/14567-timer-aufnahmen-fehlen-wegen-belegter-tuner.html#post136471
